### PR TITLE
Fix audioTrack.isEnabled is always `NO`

### DIFF
--- a/src/MediaStream/RTCMediaStreamConstraints.js
+++ b/src/MediaStream/RTCMediaStreamConstraints.js
@@ -104,6 +104,12 @@ export default class RTCMediaStreamConstraints {
                 frameRate: video.frameRate
             };
         }
+        var audio = this.audio;
+        if(audio === true || audio === null){
+          json.audio = DEFAULT_AUDIO_CONSTRAINTS;
+        } else {
+          json.audio = audio;
+        }
 
         return json;
     }

--- a/src/MediaStream/RTCMediaStreamConstraints.js
+++ b/src/MediaStream/RTCMediaStreamConstraints.js
@@ -75,7 +75,7 @@ export default class RTCMediaStreamConstraints {
      * デフォルトの制約は以下の通りです。
      * 
      * - `video.facingMode = 'user'`
-     * - `video.widtch = 1280`
+     * - `video.width = 1280`
      * - `video.height = 720`
      * - `video.frameRate = 30`
      * - `audio = true`


### PR DESCRIPTION
WebRTC.js にて `getUserMedia(constraints.toJSON())` する際に `audio` プロパティが https://github.com/shiguredo/react-native-webrtc-kit/blob/master/src/MediaStream/RTCMediaStreamConstraints.js#L92 にて欠落しているため、 audioTrack.isEnabled が常に無効の状態になっていました。

## Solution
`RTCMediaStreamConstraints:toJSON` メソッドで返す Object に audio プロパティを付与する