### PR TITLE
NSGenericException を回避するため、_trackValueTags を一旦コピーする

### DIFF
--- a/ios/WebRTCModule+getUserMedia.m
+++ b/ios/WebRTCModule+getUserMedia.m
@@ -142,7 +142,9 @@ static WebRTCCameraVideoCapturer *sharedCameraVideoCapturer = nil;
     // ただし、すべてのタグを一度に消すために
     // 毎回チェック用の配列を用意すると重いので、一度に一つずつ消す
     NSString *tagToRemove = nil;
-    for (NSString *valueTag in _trackValueTags) {
+    // 配列を一旦コピーする
+    NSArray<NSString *> *trackValueTags = [_trackValueTags copy];
+    for (NSString *valueTag in trackValueTags) {
         RTCMediaStreamTrack *track = [WebRTCModule shared].tracks[valueTag];
         if ([track isKindOfClass: [RTCVideoTrack class]] &&
             track.readyState == RTCMediaStreamTrackStateLive) {


### PR DESCRIPTION
バグフィックスです。
## 概要
グローバルなMutable Array  である `_trackValueTags` を for で参照している最中に、
valueTag の破棄等で参照先が失われた際に

```
NSGenericException:
-[WebRTCCameraVideoCapturer capturer:didCaptureVideoFrame:] .../node_modules/react-native-webrtc-kit/ios/WebRTCModule+getUserMedia.m:145
```
でアプリがクラッシュする場合を確認しました。

## 対応

Mutable Array である `_trackValueTags` を一旦 `trackValueTags` にコピーして `for` 参照することで対応しました。
この変更によりクラッシュを回避できることを実機で確認済みです。
