### PR TITLE
Update: Android gradleと使用するSDKのバージョンを更新

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -2,24 +2,31 @@
 buildscript {
     repositories {
         jcenter()
+        google()
+        maven { url 'https://jitpack.io' }
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.2.3'
+        classpath 'com.android.tools.build:gradle:3.2.1'
     }
 }
 
 apply plugin: 'com.android.library'
 
 android {
-    compileSdkVersion 23
-    buildToolsVersion "23.0.1"
+    compileSdkVersion 26
+    buildToolsVersion "26.0.3"
 
     defaultConfig {
         minSdkVersion 16
-        targetSdkVersion 22
+        compileSdkVersion 26
+        targetSdkVersion 26
         versionCode 1
         versionName "1.0"
+    }
+    compileOptions {
+        sourceCompatibility JavaVersion.VERSION_1_8
+        targetCompatibility JavaVersion.VERSION_1_8
     }
     lintOptions {
         abortOnError false
@@ -28,11 +35,13 @@ android {
 
 repositories {
     mavenCentral()
+    jcenter()
+    google()
     maven { url 'https://jitpack.io' }
 }
 
 dependencies {
-    compile 'com.facebook.react:react-native:+'
-    compile "com.github.shiguredo:sora-webrtc-android:66.8.1.1" // should be `api` if android gradle plugin is 3.0+
+    api 'com.facebook.react:react-native:+'
+    api "com.github.shiguredo:sora-webrtc-android:66.8.1.1"
 }
   

--- a/android/gradle/wrapper/gradle-wrapper.properties
+++ b/android/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Sat Jun 23 17:09:01 JST 2018
+#Wed Oct 10 10:43:58 ICT 2018
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-2.14.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.6-all.zip


### PR DESCRIPTION
Androidをgradle 3.2.1, SDK 28でビルドするようにしました。
まだコード自体はありませんが、ひとまずこれでビルド体制はOKです。
使用するSDKのバージョンについては今年の8月からAPI level 29が必須になるため、特に問題なければ後々SDK 29を使用するように修正しますが、まずは今安定してビルドに成功している28を使います。