### PR TITLE
PeerConnection.removeTrack() の返り値を Promise<void> に修正する

### DIFF
--- a/src/PeerConnection/RTCPeerConnection.js
+++ b/src/PeerConnection/RTCPeerConnection.js
@@ -363,10 +363,14 @@ export default class RTCPeerConnection extends RTCPeerConnectionEventTarget {
    * 
    * @since 1.1.0
    */
-  removeTrack(sender: RTCRtpSender) {
+  removeTrack(sender: RTCRtpSender): Promise<void> {
     this.senders = this.senders.filter(
       e => e.id != sender.id);
-    WebRTC.peerConnectionRemoveTrack(this._valueTag, sender._valueTag);
+    return WebRTC.peerConnectionRemoveTrack(this._valueTag, sender._valueTag)
+      .then(() => {
+        console.log("removeTrack: sender => ", sender);
+        return;
+      });
   }
 
   /**

--- a/src/WebRTC.js
+++ b/src/WebRTC.js
@@ -55,7 +55,7 @@ export default class WebRTC {
     return WebRTCModule.peerConnectionAddTrack(trackValueTag, streamIds, valueTag);
   }
 
-  static peerConnectionRemoveTrack(valueTag: ValueTag, senderValueTag: ValueTag) {
+  static peerConnectionRemoveTrack(valueTag: ValueTag, senderValueTag: ValueTag): Promise<void> {
     WebRTCModule.peerConnectionRemoveTrack(senderValueTag, valueTag);
   }
 

--- a/src/WebRTC.js
+++ b/src/WebRTC.js
@@ -56,7 +56,7 @@ export default class WebRTC {
   }
 
   static peerConnectionRemoveTrack(valueTag: ValueTag, senderValueTag: ValueTag): Promise<void> {
-    WebRTCModule.peerConnectionRemoveTrack(senderValueTag, valueTag);
+    return WebRTCModule.peerConnectionRemoveTrack(senderValueTag, valueTag);
   }
 
   static peerConnectionClose(valueTag: ValueTag) {


### PR DESCRIPTION
## 概要

`WebRTCModule.peerConnectionRemoveTrack()` の実装を見ると、 resolve/reject で返しているのですが、(resolve の返り値は void です)

https://github.com/shiguredo/react-native-webrtc-kit/blob/develop/ios/WebRTCModule%2BRTCPeerConnection.m#L473

- RTCPeerConnection.m
```Objective-C

RCT_EXPORT_METHOD(peerConnectionRemoveTrack:(nonnull NSString *)senderValueTag
                  valueTag:(nonnull NSString *)valueTag
                  resolver:(nonnull RCTPromiseResolveBlock)resolve
                  rejecter:(nonnull RCTPromiseRejectBlock)reject) {
    RTCPeerConnection *peerConnection = [self peerConnectionForKey: valueTag];
    if (!peerConnection) {
        reject(@"NotFoundError", @"peer connection is not found", nil);
        return;
    }
    RTCRtpSender *sender = [self senderForKey: senderValueTag];
    if (!sender) {
        reject(@"NotFoundError", @"sender is not found", nil);
        return;
    }
    
    [self removeSenderForKey: senderValueTag];
    if ([peerConnection removeTrack: sender]) {
        resolve(nil);
    } else {
        reject(@"RemoveTrackFailed", @"cannot remove track", nil);
    }
}
```

JS の `src/WebRTC.js` 及び `src/PeerConnection/RTCPeerConnection.js` の返り値が `Promise<void>` ではなく `void` になっていたので、型アノテーションの指定及び `then` 節の付与を行いました。

お手数ですがご確認お願いします。
