### PR TITLE
Android アプリのクラッシュを修正

### DIFF
--- a/android/src/main/java/jp/shiguredo/react/webrtckit/WebRTCConverter.java
+++ b/android/src/main/java/jp/shiguredo/react/webrtckit/WebRTCConverter.java
@@ -222,12 +222,16 @@ final class WebRTCConverter {
 
     @NonNull
     static String rtpTransceiverDump(@NonNull final RtpTransceiver transceiver) {
-        return String.format("%s, %s %b [%s] [%s]",
-                transceiver.getMediaType(),
-                rtpTransceiverDirectionStringValue(transceiver.getDirection()),
-                transceiver.isStopped(),
-                rtpReceiverDump(transceiver.getReceiver()),
-                rtpSenderDump(transceiver.getSender()));
+        try {
+            return String.format("%s, %s %b [%s] [%s]",
+                    transceiver.getMediaType(),
+                    rtpTransceiverDirectionStringValue(transceiver.getDirection()),
+                    transceiver.isStopped(),
+                    rtpReceiverDump(transceiver.getReceiver()),
+                    rtpSenderDump(transceiver.getSender()));
+        } catch (IllegalStateException e) {
+            return e.getMessage();
+        }
     }
 
     //endregion
@@ -521,10 +525,14 @@ final class WebRTCConverter {
 
     @NonNull
     static String mediaStreamTrackDump(@NonNull final MediaStreamTrack track) {
-        return String.format("%s (%s) %b",
-                track.kind(),
-                mediaStreamTrackStateStringValue(track.state()),
-                track.enabled());
+        try {
+            return String.format("%s (%s) %b",
+                    track.kind(),
+                    mediaStreamTrackStateStringValue(track.state()),
+                    track.enabled());
+        } catch (IllegalStateException e) {
+            return e.getMessage();
+        }
     }
 
     //endregion


### PR DESCRIPTION
## 概要

setTrack 内に track や repository の状態をダンプするコードがありますが、既に破棄されたリソースをダンプしてクラッシュするケース(添付画像)があったので修正しました

修正前は `接続 ~ 接続解除` を複数回行っていると以下のいずれかのエラーが発生していました

- java.lang.IllegalStateException: MediaStreamTrack has been disposed.
- java.lang.IllegalStateException: RtpTransceiver has been disposed.

## react-native-webrtc-kit 内の該当箇所
https://github.com/shiguredo/react-native-webrtc-kit/blob/5c333f8799b1c3a8d92b5da46ad09032d36bba0f/android/src/main/java/jp/shiguredo/react/webrtckit/WebRTCVideoViewManager.java#L119

## 修正後出力されたログ

```
...
2020-01-07 00:53:08.911 25134-25134/com.hellosora D/WebRTCVideoView: repository.tracks.dump()=
     * ID - ValueTag - Value
     * 735f8ad9-3941-489b-a64b-0ad52ef5a8e0 - ec29ea17-5e15-4e4d-95ef-1be70f5a2a8e - video (ended) true
     * d361a304-3599-43cc-aa4d-1762740dc543 - 959772e1-cb95-4b49-b6b4-1a77437d9fc4 - audio (live) true
     * 7fdbb6c4-58aa-4f71-bf76-72081eb9c118 - 2956ad34-7c63-4d31-a506-de5919f6ab13 - video (ended) true
     * c55d77bb-1c68-4707-bd6d-f06edba1b964 - 1e9f275c-3044-4fac-a90c-7083e0582d20 - MediaStreamTrack has been disposed.
     * 08cf03b4-7f4d-4978-8d3f-10cec85bbefa - e1c506c5-1271-4887-84bb-d07a568838be - audio (live) true
     * b48a8b2e-55b4-431c-92d1-b9eefbc54869 - 57401541-b787-4d0e-a6a6-eb882c90a0df - video (ended) true
     * 419a6284-8a20-40b2-b593-0a8023369f84 - a0c66089-8a25-4261-a9da-02d8ff6008a1 - audio (live) true
     * 885f56e8-2d9b-4fc3-9e6e-f28059d2e4d9 - 0ac886b3-8080-4310-9e26-b6338c107aef - audio (live) true
     * 2e626fcd-5473-4278-8e56-53f7b7b80359 - 77684818-4c40-4340-9220-cfa66b020484 - audio (live) true
     * d09e47c0-2e82-4eb2-95ef-3c2c03829e01 - 3ce983a0-ffd4-4abd-b898-7c033ec7c45e - audio (live) true
     * 722fd595-e86f-48df-9957-b35096137e60 - 8f81db7a-02de-4202-b421-c704ed102fda - video (live) true
     * 8dbec99d-fc93-4a15-97fe-dfaece2ed79f - 64f2994b-f815-4bcc-ac2c-c2707c0b39cc - video (ended) true
     * 149454db-e5df-4bcf-ab20-2a9e7fc44e38 - 18da6e1d-be25-49d5-9623-26d2820109f9 - video (ended) true
     * 403cbb84-8def-4aad-aa49-7ce1c7804401 - 5927fbb0-f024-4040-a647-147a47f6cd70 - video (live) true
     * 087e9ab0-bd12-4a30-b326-a932a66d12b5 - 0c55ca8b-f23d-4c0f-bee6-be9d525d402c - audio (live) true
     * be96ef1f-de47-4d30-9438-3abbbab5c910 - 39bdb279-fd46-4f08-be6a-ed3a6b4b02a3 - audio (live) true
     * 56ff3fc2-dc5b-4f7a-acb7-e394bc9ef985 - 002cda21-e735-4199-a984-693ebc892a97 - video (ended) true
     * 96793e70-2534-4135-814b-03854908156b - 5a589639-7632-43a1-8dd1-c13688967363 - audio (live) true
     * 9c76a1bf-bb7f-4996-98d8-c30ea84bc3fd - 02054020-8305-4aba-985d-279818c30f99 - video (ended) true
     * dc07a0b9-2336-4b83-a18a-66830e2a4aaf - be313781-d6ca-4575-8ba9-6df74436ad23 - MediaStreamTrack has been disposed.
2020-01-07 00:53:08.913 25134-25134/com.hellosora D/WebRTCVideoView: repository.transceiver.dump()=
     * ID - ValueTag - Value
     * audio_2wVIBa - 2ce1b1c8-5329-452e-b2f4-dee47184dba2 - MEDIA_TYPE_AUDIO, recvonly false [receiver -> audio (live) true] [sender -> no track]
     * audio_WYsjBm - fc71394f-99c0-4bab-b286-29d16d4eb8f8 - RtpTransceiver has been disposed.
     * video_dg7ZKU - b0012223-6484-4707-a67d-67dae1d9120a - MEDIA_TYPE_VIDEO, recvonly false [receiver -> video (live) true] [sender -> no track]
     * video_sFoCMI - 885822ff-7a87-4350-8179-343043ba0baa - RtpTransceiver has been disposed.
...
```

## エラー

![71613392-91b2a600-2be9-11ea-9cca-a8622b72e1a2](https://user-images.githubusercontent.com/17097142/71829677-816a6180-30e8-11ea-9500-65c38ef1b053.png)