### PR TITLE
iOS でトラック削除時のイベント名を typo していたので修正する

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -9,6 +9,11 @@
 - FIX
     - バグ修正
 
+## develop
+
+- [FIX] iOS でトラック削除時のイベント名を typo していたので修正する
+    - @enm10k
+
 ## 2020.3.0
 
 - [ADD] DataChannel に対応する

--- a/ios/WebRTCModule+RTCPeerConnection.m
+++ b/ios/WebRTCModule+RTCPeerConnection.m
@@ -709,7 +709,7 @@ didChangeConnectionState:(RTCPeerConnectionState)newState
     }
 
     [self.bridge.eventDispatcher
-     sendDeviceEventWithName: @"peerConnectionRemoveReceiver"
+     sendDeviceEventWithName: @"peerConnectionRemovedReceiver"
      body:@{@"valueTag": peerConnection.valueTag,
             @"receiver": [rtpReceiver json]}];
 }


### PR DESCRIPTION
タイトルにある通り、イベント名を typo している箇所があったので修正しました